### PR TITLE
Add the compiled binary and runtime files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@
 *.a
 *.so
 
+# Compiled binary
+ecca-proxy
+
+# Runtime generated files
+ecca-proxy.sqlite3
+
 # Folders
 _obj
 _test


### PR DESCRIPTION
This adds the binary (`ecca-proxy`) and the database it creates to the
gitignore.

This prevents accidental tracking of the binary in git.