### PR TITLE
Split templates in separate files and use go rice to open them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,26 @@
 
 # Just so I won't forget it
 
-.PHONY:	ecca-proxy
+.PHONY:	ecca-proxy release all rice-box dev clean distclean
+
+all: ecca-proxy
+
+release: rice-box ecca-proxy
+dev: clean ecca-proxy
+
 
 ecca-proxy:
 	go build -o ecca-proxy *.go
+
+
+rice-box: *.go
+	go get github.com/GeertJohan/go.rice
+	go get github.com/GeertJohan/go.rice/rice
+	${GOPATH}/bin/rice embed-go -v
+
+clean:
+	rm -f rice-box.go
+	rm -f ecca-proxy
+
+distclean: clean
+	rm -f ecca-proxy.sqlite3

--- a/templates/embed.html
+++ b/templates/embed.html
@@ -1,0 +1,23 @@
+<html>
+  <body>
+    <p>Ecca Proxy. You are logged in {{ .Hostname }} with {{ .CN }}.
+    Press here to logout:
+    <form method="POST" action="/manage">
+      <input type="hidden" name="logout" value="{{ .Hostname }}">
+      <input type="submit" name="button" value="Log out of {{ .Hostname }}">
+    </form></p>
+    <p>Click here to go to the <a href="/manage">management page</a> of the proxy</p>
+    <hr>
+    <iframe src="{{ .URL }}" width="100%" height="100%">
+      [Your user agent does not support frames or is currently configured
+      not to display frames.
+      However, you may visit <a href="{{ .URL }}">{{ .URL }}</a>.
+      <br>
+      To log out:
+      <form method="POST" action="/manage">
+        <input type="hidden" name="logout" value="{{ .Hostname }}">
+        <input type="submit" name="button" value="Log out of {{ .Hostname }}">
+      </form>]
+    </iframe>
+  </body>
+</html>

--- a/templates/select.html
+++ b/templates/select.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="container">
+      <h1>401 - Eccentric Authentication required</h1>
+      <form method="POST" >
+	<div class="form-group">
+	  <p>Please select one of these identies</p>
+	  {{ range . }}
+	  <input type="submit" name="login" value="{{ .CN }}">
+	  {{ else }}
+	  <h3> No identities available </h3>
+	  {{ end }}
+	  <br>
+	</div>
+	<div class="form-group">
+	  <p>Or create a new one</p>
+	  <input type="text" name="cn" class="form-control">
+	  <input type="submit" name="register" value="Register this name">
+	  <br>
+	</div>
+	<div class="form-group">
+	  <p>Or register anonymously:</p>
+	  <input type="submit" name="anonymous" value="Anonymous">
+	</div>
+      </form>
+    </div>
+  </body>
+</html>
+

--- a/templates/showLogins.html
+++ b/templates/showLogins.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="container">
+      <h1>Manage your Eccentric Authentication logins</h1>
+      <h3>Current logins</h3>
+      {{ if .current }}
+      <p>
+      <table>
+        <thead><tr><th>Host</th><th>Account</th><th>Action</th></tr></thead>
+        <tbody>
+          {{range $hostname, $cred := .current }}
+          <tr><td>{{ $hostname }}</td>
+            <td>{{ $cred.CN }}</td>
+            <td>
+              <form method="POST">
+                <input type="hidden" name="logout" value="{{ .Hostname }}">
+                <input type="submit" name="button" value="Log out of {{ .Hostname }}">
+              </form>
+            </td>
+          </tr>
+          {{ end }}
+        </tbody>
+      </table>
+      </p>
+      {{ else }}
+      <p><em>You are not logged in anywhere.</em></p>
+      {{ end }}
+
+      <h3>All your accounts at hosts</h3>
+      <p>These are all your accounts we have private keys for.
+      <br>You can log in to any. Just click on the host name to get there anonymously.
+      <br>You'll get to choose the account when the sites asks for one.</p>
+      <p>
+      <table>
+        <thead>
+          <tr><th>Host</th>
+            <th>Accounts</th>
+            <th>Invited</th>
+            <th>App</th>
+            <!-- <th>Show full certificate</th> -->
+          </tr>
+        </thead>
+        <tbody>
+          {{ range $hostname, $details := .alldetails }}
+          <tr>
+            <td><a href="http://{{ $hostname }}/">{{ $hostname }}</a></td>
+            <td>{{ range $details }}{{ .ListenerCN        }}<br/>{{ end }}</td>
+            <td>{{ range $details }}{{ or .CallerCN    "" }}<br/>{{ end }}</td>
+            <td>{{ range $details }}{{ or .Application "" }}<br/>{{ end }}</td>
+          </tr>
+          {{ else }}
+          <tr><td colspan="4">You have no accounts anywhere. </td></tr>
+          {{ end }}
+        </tbody>
+      </table>
+      </p>
+    </div>
+  </body>
+</html>

--- a/user.go
+++ b/user.go
@@ -31,6 +31,7 @@ import (
 	MathRand   "math/rand"
 	"github.com/gwitmond/eccentric-authentication" // package eccentric
 	"github.com/gwitmond/socks4a"
+        "github.com/GeertJohan/go.rice"
 )
 
 // Global config
@@ -55,44 +56,6 @@ func redirectToSelector(req *http.Request) (*http.Response) {
 // We show a simple form with the available credentials and allow the option to
 // create a new one.
 
-var selectTemplate = template.Must(template.New("select").Parse(
-`<html>
-<body>
-<h1>401 - Eccentric Authentication required</h1>
-<form method="POST" >
-<p>Please select one of these identies {{ range . }} <input type="submit" name="login" value="{{ .CN }}">{{ else }} -none- {{ end }}<br>
-<p>Or create a new one</p>
-<input type="text" name="cn"><input type="submit" name="register" value="Register this name"></p><br>
-<p>Or register anonymously: <input type="submit" name="anonymous" value="Anonymous"></p>
-</form>
-</body>
-</html>`))
-
-var embedTemplate = template.Must(template.New("embed").Parse(
-`<html>
-
-<body>
-  <p>Ecca Proxy. You are logged in {{ .Hostname }} with {{ .CN }}.
-     Press here to logout:
-      <form method="POST" action="/manage">
-        <input type="hidden" name="logout" value="{{ .Hostname }}">
-        <input type="submit" name="button" value="Log out of {{ .Hostname }}">
-      </form></p>
-<p>Click here to go to the <a href="/manage">management page</a> of the proxy</p>
-<hr>
-  <iframe src="{{ .URL }}" width="100%" height="100%">
-    [Your user agent does not support frames or is currently configured
-     not to display frames.
-     However, you may visit <a href="{{ .URL }}">{{ .URL }}</a>.
-     <br>
-     To log out:
-      <form method="POST" action="/manage">
-        <input type="hidden" name="logout" value="{{ .Hostname }}">
-        <input type="submit" name="button" value="Log out of {{ .Hostname }}">
-       </form>]
-  </iframe>
-</body>
-</html>`))
 
 // eccaHandler: learn the users' selected account and set it as logged in.
 // then redirect to original request (where the user want to go to)/
@@ -115,6 +78,17 @@ func eccaHandler (req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *htt
 	return nil, nil
 }
 
+// uses the name to render "templates/`name`.html"
+// this adds the boilerplate of head.html and navbar.html
+func constructTemplate(name string) (*template.Template) {
+
+        var templateDir = rice.MustFindBox("./templates")
+
+        var filename = name+".html"
+        var templatestring = templateDir.MustString(filename)
+        var templ = template.Must(template.New(name).Parse(templatestring))
+        return templ
+}
 
 func handleSelect (req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	var originalURL *url.URL
@@ -133,6 +107,7 @@ func handleSelect (req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *ht
 		// User has no active logins.
 		// Show available client certificates for URI.Host
 		creds := getCreds(originalURL.Host)
+                var selectTemplate = constructTemplate("select")
 		buf := execTemplate(selectTemplate, "select", creds)
 		resp := makeResponse(req, 200, "text/html", buf)
 		return nil, resp
@@ -171,6 +146,7 @@ func handleSelect (req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *ht
 			"CN": cred.CN,
 			"URL": originalURL.String(),
 		}
+                var embedTemplate = constructTemplate("embed")
 		buf := execTemplate(embedTemplate, "embed", data)
 		resp := makeResponse(req, 200, "text/html", buf)
 		return nil, resp
@@ -282,72 +258,6 @@ func signupPubkey(client *http.Client, registerURL string, cn string, pub rsa.Pu
 //------------------ Manager
 // show current logins and allow for logouts.
 
-var showLoginTemplate = template.Must(template.New("showLogins").Parse(
-`<html>
-<head>
-  <style>
-    table { border-top: 1px solid gray; border-bottom: 1px solid gray; }
-    tbody tr { background: #eee; }
-  </style>
-</head>
-<body>
- <h1>Manage your Eccentric Authentication logins</h1>
- <h3>Current logins</h3>
-  {{ if .current }}
-  <p>
-    <table>
-      <thead><tr><th>Host</th><th>Account</th><th>Action</th></tr></thead>
-      <tbody>
-        {{range $hostname, $cred := .current }}
-          <tr><td>{{ $hostname }}</td>
-              <td>{{ $cred.CN }}</td>
-              <td>
-                <form method="POST">
-                  <input type="hidden" name="logout" value="{{ .Hostname }}">
-                  <input type="submit" name="button" value="Log out of {{ .Hostname }}">
-                </form>
-              </td>
-          </tr>
-        {{ end }}
-      </tbody>
-    </table>
-  </p>
- {{ else }}
-   <p><em>You are not logged in anywhere.</em></p>
- {{ end }}
-
- <h3>All your accounts at hosts</h3>
-   <p>These are all your accounts we have private keys for.
-     <br>You can log in to any. Just click on the host name to get there anonymously.
-     <br>You'll get to choose the account when the sites asks for one.</p>
-     <p>
-     <table>
-     <thead>
-       <tr><th>Host</th>
-           <th>Accounts</th>
-           <th>Invited</th>
-           <th>App</th>
-           <!-- <th>Show full certificate</th> -->
-       </tr>
-     </thead>
-     <tbody>
-       {{ range $hostname, $details := .alldetails }}
-         <tr>
-           <td><a href="http://{{ $hostname }}/">{{ $hostname }}</a></td>
-           <td>{{ range $details }}{{ .ListenerCN        }}<br/>{{ end }}</td>
-           <td>{{ range $details }}{{ or .CallerCN    "" }}<br/>{{ end }}</td>
-           <td>{{ range $details }}{{ or .Application "" }}<br/>{{ end }}</td>
-         </tr>
-       {{ else }}
-         <tr><td colspan="4">You have no accounts anywhere. </td></tr>
-       {{ end }}
-     </tbody>
-     </table>
-   </p>
-</body>
-</html>`))
-
-
 func handleManager (req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 	req.ParseForm()
 	log.Printf("Form parameters are: %v\n", req.Form)
@@ -356,6 +266,7 @@ func handleManager (req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *h
 	case "GET":
 		details := getAllDetails()
 
+                var showLoginTemplate = constructTemplate("showLogins")
 		buf  := execTemplate(showLoginTemplate, "showLogins", map[string]interface{}{
 			"current":    logins,
 			"alldetails": details,


### PR DESCRIPTION
Go rice is a library that allows for the inclusion of static external files (like templates or css files) inside the final binary.

It always loads from disk in a `dev` build, so no recompilations are necessary while changing the external files (i.e. the templates); a page reload will do.

Go rice has the advantage of making it possible to embed the external
files into the binary (see the `release` target in the makefile).

This PR:
- adds go.rice as a dependency
- splits the templates for `/select`, `/embed` and `/manage` into separate files in a `templates/` subdirectory (without changing the templates themselves)
- uses go.rice to load the templates.
- changes the `Makefile` to make working with go.rice easier

Please let me know what you think