### PR TITLE
Make `ecca.handler/select` more visually appealing

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -81,7 +81,7 @@ func main() {
 	//server6.SetKeepAlivesEnabled(false)
 
 	server4 := &http.Server {
-          Addr: fmt.Sprintf("%s:%d", *ip4ListenAddr, *port),
+		Addr: fmt.Sprintf("%s:%d", *ip4ListenAddr, *port),
 		Handler: proxy,
 	}
 	// TODO: disable KeepAlives when your golang version supports it

--- a/templates/head.html
+++ b/templates/head.html
@@ -1,0 +1,15 @@
+{{define "head"}}
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <style>
+    table { border-top: 1px solid gray; border-bottom: 1px solid gray; }
+    tbody tr { background: #eee; }
+  </style>
+  <link rel="stylesheet" href="/static?file=css/bootstrap.min.css">
+  <link rel="icon" href="/static?file=img/favicon.png">
+  <script src="/static?file=js/jquery-3.1.1.slim.min.js" ></script>
+  <script src="/static?file=js/tether.min.js" ></script>
+  <script src="/static?file=js/bootstrap.min.js" ></script>
+</head>
+{{end}}

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -1,0 +1,15 @@
+{{define "navbar"}}
+<nav class="navbar navbar-toggleable-md navbar-light bg-faded mb-3">
+  <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <a class="navbar-brand" href="#">Eccentric Authentication</a>
+  <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+    <div class="navbar-nav">
+      <a class="nav-item nav-link" href="/manage">Manage</a>
+      <a class="nav-item nav-link" href="/select">Select</a>
+      <a class="nav-item nav-link" href="/showcert">Show Cert</a>
+    </div>
+  </div>
+</nav>
+{{end}}

--- a/templates/select.html
+++ b/templates/select.html
@@ -1,28 +1,75 @@
 <!DOCTYPE html>
 <html>
+  {{template "head"}}
   <body>
     <div class="container">
-      <h1>401 - Eccentric Authentication required</h1>
-      <form method="POST" >
-	<div class="form-group">
-	  <p>Please select one of these identies</p>
-	  {{ range . }}
-	  <input type="submit" name="login" value="{{ .CN }}">
-	  {{ else }}
-	  <h3> No identities available </h3>
-	  {{ end }}
-	  <br>
-	</div>
-	<div class="form-group">
-	  <p>Or create a new one</p>
-	  <input type="text" name="cn" class="form-control">
-	  <input type="submit" name="register" value="Register this name">
-	  <br>
-	</div>
-	<div class="form-group">
-	  <p>Or register anonymously:</p>
-	  <input type="submit" name="anonymous" value="Anonymous">
-	</div>
+      {{template "navbar" }}
+      <form method="POST">
+        <div class="row">
+          <div class="col-md-6 col-sm-12">
+            <div class="row text-center">
+              <div class="col">
+                {{if gt (len $) 0 }}
+                <h3>Use an existing identity</h3>
+                {{else}}
+                <h3>No existing identities</h3>
+                {{end}}
+              </div>
+            </div>
+            {{ range $i, $x := $ }}
+            {{ $name := printf "%.25s" $x.CN }}
+            <div class="jumbotron mt-3 p-2">
+              <div class="row">
+                <div class="col">
+                  <input type="hidden" name="login" value="{{$x.CN}}"/>
+                  <button type="submit"
+                  class="btn btn-info btn-block"
+                  >
+                  {{ $name }}{{ if gt (len $x.CN) 25}}{{"..."}}{{end}}
+                </button>
+                </div>
+              </div>
+            </div>
+            {{else}}
+            <div class="col mx-0">
+                <div class="jumbotron my-3 mx-0 p-2">
+                  <p>
+                    You do not have any identities with this website, please create one with the menu on the right.
+                  </p>
+                  <p>
+
+                  </p>
+                </div>
+              </div>
+            {{end}}
+          </div>
+          <div class="col-sm-12 col-md-6">
+            <div class="row text-center">
+              <div class="col">
+                <h3>Create a new identity</h3>
+              </div>
+            </div>
+            <div class="row text-center mt-3 pr-3">
+              <div class="form-group" style="width:100%">
+                <div class="form-inline" style="width:100%">
+                  <label for="new_name" class="sr-only">Choose your own name</label>
+                  <div class="input-group" style="width:100%">
+                    <input type="text" class="form-control" placeholder="Choose your own name">
+                    <span class="input-group-btn">
+                      <button class="btn btn-outline-primary" type="submit" style="width:auto;">Register this name</button>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="row text-center pr-3">
+              <div class="form-group" style="width:100%">
+                <label for="register_anonymous" class="sr-only">Or register anonymously:</label>
+                <input type="submit" name="anonymous" value="Or register anonymously" id="register_anonymous" class="form-control btn btn-outline-warning">
+              </div>
+            </div>
+          </div>
+        </div>
       </form>
     </div>
   </body>


### PR DESCRIPTION
This is part of #3 which has been split up into several PR's for ease of reviewing.

The foundation of rice.go has been merged (see #4 ) which allows static files to be served ( #6 ) this builds on top of those by using the twitter bootstrap to update the style of the page.


Please let me know what you think.