### PR TITLE
Add creation and login timestamps

### DIFF
--- a/account.go
+++ b/account.go
@@ -45,11 +45,14 @@ func getServerCreds (realm string) (serverCert, bool) {
 
 //-------------------- client data
 type credentials struct {
+	Id	 int64		 // for the database
 	Hostname string          // the hostname
 	Realm    string          // the realm for these credentials.  (The part after the @@? )
 	CN       string          // the username
 	Cert     []byte          // the client certificate without private key
 	Priv     []byte          // the private key that matches the certificate.
+	Created  int64		 // unix timestamp due to DB driver (gorp)
+	LastUsed int64		 // unix timestamp due to DB driver (gorp)
 }
 
 //-------------------- Logins
@@ -75,6 +78,7 @@ func login(host string, cred credentials) {
 	hostname := strings.ToLower(getHostname(host))
 	logins[hostname] = cred
 	log.Println("logging in ", cred.CN, " at ", hostname)
+	updateLastUsedTime(cred)
 }
 
 func logout(host string) {

--- a/datastore.go
+++ b/datastore.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/gorp.v1"
         "database/sql"
         _ "github.com/mattn/go-sqlite3"
+	"time"
 )
 
 
@@ -25,7 +26,7 @@ func init_datastore(datastore string) {
         db, err := sql.Open("sqlite3", datastore)
         check(err)
         dbmap = &gorp.DbMap{Db: db, Dialect: gorp.SqliteDialect{}}
-        dbmap.AddTableWithName(credentials{}, "credentials")  // .SetKeys(false, "CN", "Realm")
+        dbmap.AddTableWithName(credentials{}, "credentials").SetKeys(true, "Id")
 	dbmap.AddTableWithName(listener{}, "listeners")
         dbmap.CreateTables() // if not exists
 
@@ -37,6 +38,13 @@ func init_datastore(datastore string) {
 // People can have multiple accounts a host.
 func setCredentials(cred credentials) {
 	check(dbmap.Insert(&cred))
+}
+
+func updateLastUsedTime(cred credentials) {
+
+	cred.LastUsed = time.Now().Unix()
+	_, err := dbmap.Update(&cred)
+	check(err)
 }
 
 // Just get all credentials... (sorted by getCredentials)

--- a/templates/select.html
+++ b/templates/select.html
@@ -18,7 +18,7 @@
             </div>
             {{ range $i, $x := $ }}
             {{ $name := printf "%.25s" $x.CN }}
-            <div class="jumbotron mt-3 p-2">
+            <div class="jumbotron m-3 p-2">
               <div class="row">
                 <div class="col">
                   <input type="hidden" name="login" value="{{$x.CN}}"/>

--- a/templates/select.html
+++ b/templates/select.html
@@ -29,6 +29,18 @@
                 </button>
                 </div>
               </div>
+              <div class="row">
+                <div class="col-sm-6">
+                  <label for="created-date-{{$x.CN}}" class="small">Created:</label>
+                  <div id="created-date-{{$x.CN}}" class="small">{{ unixToDateTime $x.Created}}</div>
+                </div>
+                <div class="col-sm-6">
+                  <label for="last-used-date-{{$x.CN}}" class="small">Last Used:</label>
+                  <div id="last-used-date-{{$x.CN}} small" class="small">
+                    {{ if $x.LastUsed }}{{ unixToDateTime $x.LastUsed}}{{ else }}Never{{end}}
+                  </div>
+                </div>
+              </div>
             </div>
             {{else}}
             <div class="col mx-0">

--- a/user.go
+++ b/user.go
@@ -24,6 +24,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"time"
 	"os/exec"
 	"strconv"
 	"regexp"
@@ -119,6 +120,10 @@ func constructTemplate(name string) (*template.Template) {
 		"mod": func(a int, b int) int {
 			return a % b
 		},
+		"unixToDateTime": func(timestamp int64) string {
+			return time.Unix(timestamp, 0).Format("Monday 02 January 2006 15:04")
+		},
+
 	}
 
 
@@ -278,12 +283,15 @@ func registerCN(hostname string, cn string) (*credentials, error) {
 
 	var privPEM  bytes.Buffer
 	pem.Encode(&privPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+
 	creds := credentials{
 		Hostname: hostname,
 		Realm: "",
 		CN: cn,
 		Cert: cert,
 		Priv: privPEM.Bytes(),
+		Created: time.Now().Unix(),
+		LastUsed: time.Now().Unix(), // user is logged-in immedeatly
 	}
 	// Register the data and set it as login certificate
 	// It's what the user would expect from signup.


### PR DESCRIPTION
This adds timestamps to the local database. 
One for account creation and one for last use.
This will be more helpful in choosing the account to log in with, because you can see when it was created and when it was last used. In the future the user might be able to sort the accounts listed by either.