### PR TITLE
add local notes to accounts

### DIFF
--- a/account.go
+++ b/account.go
@@ -51,6 +51,7 @@ type credentials struct {
 	CN       string          // the username
 	Cert     []byte          // the client certificate without private key
 	Priv     []byte          // the private key that matches the certificate.
+	Comment  string          // notes the user can add to the account
 	Created  int64		 // unix timestamp due to DB driver (gorp)
 	LastUsed int64		 // unix timestamp due to DB driver (gorp)
 }

--- a/datastore.go
+++ b/datastore.go
@@ -11,7 +11,6 @@ package main // eccaproxy
 
 import (
 	"fmt"
-
 	// These are for the data storage
 	"gopkg.in/gorp.v1"
         "database/sql"
@@ -39,6 +38,7 @@ func init_datastore(datastore string) {
 func setCredentials(cred credentials) {
 	check(dbmap.Insert(&cred))
 }
+
 
 func updateLastUsedTime(cred credentials) {
 

--- a/templates/select.html
+++ b/templates/select.html
@@ -4,9 +4,9 @@
   <body>
     <div class="container">
       {{template "navbar" }}
-      <form method="POST">
-        <div class="row">
-          <div class="col-md-6 col-sm-12">
+      <div class="row">
+        <div class="col-md-6 col-sm-12">
+          <form method="POST">
             <div class="row text-center">
               <div class="col">
                 {{if gt (len $) 0 }}
@@ -23,10 +23,10 @@
                 <div class="col">
                   <input type="hidden" name="login" value="{{$x.CN}}"/>
                   <button type="submit"
-                  class="btn btn-info btn-block"
-                  >
-                  {{ $name }}{{ if gt (len $x.CN) 25}}{{"..."}}{{end}}
-                </button>
+                    class="btn btn-info btn-block"
+                    >
+                    {{ htmlescape $name }}{{ if gt (len $x.CN) 25}}{{"..."}}{{end}}
+                  </button>
                 </div>
               </div>
               <div class="row">
@@ -41,21 +41,30 @@
                   </div>
                 </div>
               </div>
-            </div>
-            {{else}}
-            <div class="col mx-0">
-                <div class="jumbotron my-3 mx-0 p-2">
+              <div class="row">
+                <div class="col-sm-6">
                   <p>
-                    You do not have any identities with this website, please create one with the menu on the right.
-                  </p>
-                  <p>
-
+                    {{ htmlescape $x.Comment }}
                   </p>
                 </div>
               </div>
+            </div>
+            {{else}}
+            <div class="col mx-0">
+              <div class="jumbotron my-3 mx-0 p-2">
+                <p>
+                  You do not have any identities with this website, please create one with the menu on the right.
+                </p>
+                <p>
+
+                </p>
+              </div>
+            </div>
             {{end}}
-          </div>
-          <div class="col-sm-12 col-md-6">
+          </form>
+        </div>
+        <div class="col-sm-12 col-md-6">
+          <form method="POST">
             <div class="row text-center">
               <div class="col">
                 <h3>Create a new identity</h3>
@@ -66,7 +75,7 @@
                 <div class="form-inline" style="width:100%">
                   <label for="new_name" class="sr-only">Choose your own name</label>
                   <div class="input-group" style="width:100%">
-                    <input type="text" class="form-control" placeholder="Choose your own name">
+                    <input type="text" class="form-control" placeholder="Choose your own name" name="register">
                     <span class="input-group-btn">
                       <button class="btn btn-outline-primary" type="submit" style="width:auto;">Register this name</button>
                     </span>
@@ -80,9 +89,13 @@
                 <input type="submit" name="anonymous" value="Or register anonymously" id="register_anonymous" class="form-control btn btn-outline-warning">
               </div>
             </div>
+            <div class="row text-center pr-3">
+              <label for="account_notes" class="sr-only">Add a note to the new account:</label>
+              <textarea name="comment" placeholder="Add optional notes to your account (for your eyes only)  e.g. this account will only be used on every tuesday" id="account_notes" class="form-control" rows="5"></textarea>
+            </div>
           </div>
-        </div>
-      </form>
+        </form>
+      </div>
     </div>
   </body>
 </html>

--- a/templates/select.html
+++ b/templates/select.html
@@ -25,7 +25,7 @@
                   <button type="submit"
                     class="btn btn-info btn-block"
                     >
-                    {{ htmlescape $name }}{{ if gt (len $x.CN) 25}}{{"..."}}{{end}}
+                    {{ $name }}{{ if gt (len $x.CN) 25}}{{"..."}}{{end}}
                   </button>
                 </div>
               </div>
@@ -44,7 +44,7 @@
               <div class="row">
                 <div class="col-sm-6">
                   <p>
-                    {{ htmlescape $x.Comment }}
+                    {{ $x.Comment }}
                   </p>
                 </div>
               </div>

--- a/user.go
+++ b/user.go
@@ -25,7 +25,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"time"
-	"html"
 	"os/exec"
 	"strconv"
 	"regexp"
@@ -120,9 +119,6 @@ func constructTemplate(name string) (*template.Template) {
 		// The name "mod" is what the function will be called in the template text.
 		"mod": func(a int, b int) int {
 			return a % b
-		},
-		"htmlescape": func(s string) string {
-			return html.EscapeString(s)
 		},
 		"unixToDateTime": func(timestamp int64) string {
 			return time.Unix(timestamp, 0).Format("Monday 02 January 2006 15:04")


### PR DESCRIPTION
This adds the ability to add notes to an account 
(those are not sent to the website and remain local to the proxy db)
This is part of PR #3 

This is convenient for users in that it makes it possible for them to add a note to help them remember what they want to use a specific account for.

Currently, editing the notes after creation is not possible